### PR TITLE
cleanup jobBuildResult list according to LogRotator policy

### DIFF
--- a/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
+++ b/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
@@ -236,6 +236,11 @@ public class GlobalBuildStatsPlugin extends Plugin {
     		
     		getPluginBusiness().onJobCompleted(r);
     	}
+
+        @Override
+        public void onDeleted(AbstractBuild r) {
+            getPluginBusiness().onJobDeleted(r);
+        }
     }
     
     private static GlobalBuildStatsBusiness getPluginBusiness(){

--- a/src/main/java/hudson/plugins/global_build_stats/model/JobBuildResult.java
+++ b/src/main/java/hudson/plugins/global_build_stats/model/JobBuildResult.java
@@ -88,13 +88,16 @@ public class JobBuildResult implements Serializable {
 	public boolean equals(Object obj) {
 		if(obj instanceof JobBuildResult){
 			JobBuildResult r = (JobBuildResult)obj;
-			return r.buildNumber == this.buildNumber && r.jobName.equals(this.jobName)
-				// In general, "not build" results implies a job result with same jobName & buildNumber but error | failure status
-				&& r.result.equals(this.result);
+            return is(r.buildNumber, r.jobName, r.result);
 		}
-		
 		return false;
 	}
+
+    public boolean is(int buildNumer, String jobName, BuildResult result) {
+        return buildNumber == this.buildNumber && jobName.equals(this.jobName)
+            // In general, "not build" results implies a job result with same jobName & buildNumber but error | failure status
+            && result.equals(this.result);
+    }
 
 	public void setDuration(long duration) {
 		this.duration = duration;


### PR DESCRIPTION
the jobBuildResult never cleanup and can result in huge xml files and memory over-consumption.
