### PR TITLE
Performance improvement with a large data set

### DIFF
--- a/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
+++ b/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
@@ -238,7 +238,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     	}
     }
     
-    private static GlobalBuildStatsBusiness getPluginBusiness(){
+    public static GlobalBuildStatsBusiness getPluginBusiness() {
 		// Retrieving global build stats plugin & adding build result to the registered build
 		// result
     	return getInstance().business;

--- a/src/test/java/hudson/plugins/global_build_stats/business/GlobalBuildStatsBusinessTest.java
+++ b/src/test/java/hudson/plugins/global_build_stats/business/GlobalBuildStatsBusinessTest.java
@@ -1,0 +1,65 @@
+package hudson.plugins.global_build_stats.business;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.global_build_stats.GlobalBuildStatsPlugin;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class GlobalBuildStatsBusinessTest extends HudsonTestCase {
+    private GlobalBuildStatsPlugin plugin;
+    private GlobalBuildStatsBusiness business;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        plugin = GlobalBuildStatsPlugin.getInstance();
+        business = GlobalBuildStatsPlugin.getPluginBusiness();
+    }
+
+    /**
+     * Make sure builds are recorded and written out correctly.
+     */
+    public void testCallback() throws Exception {
+        List<FreeStyleProject> projects = new ArrayList<FreeStyleProject>();
+        for (int i=0; i<5; i++)
+            projects.add(createFreeStyleProject());
+
+        hudson.setNumExecutors(5);
+
+        for (int i=0; i<5; i++) {
+            List<Future<FreeStyleBuild>> builds = new ArrayList<Future<FreeStyleBuild>>();
+            for (FreeStyleProject p : projects) {
+                builds.add(p.scheduleBuild2(0));
+            }
+            // this simulates a lengthy plugin.save() and cause the grouping writes.
+            business.writer.submit(new Runnable() {
+                public void run() {
+                    try {
+                        Thread.sleep(3000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+
+            for (Future<FreeStyleBuild> f : builds) {
+                FreeStyleBuild b = assertBuildStatusSuccess(f);
+            }
+        }
+
+        // make sure we flush all the pending writes
+        business.writer.submit(new Runnable() {
+            public void run() {
+            }
+        }).get();
+
+        assertEquals(25,plugin.getJobBuildResults().size());
+    }
+}


### PR DESCRIPTION
In a bigger installation, as the number of build records grow, the
"plugin.save()" call starts to take noticable amount of time.
In one of the sites we help, it's taking in the order of minutes.

Since this code is synchronized, this creates a congestion point
where all executors that finished building gets blocked in a queue,
waiting for its turn to add one entry to the list and save the whole
list.

Since executors are precious, in this fix I've moved the plugin.save()
operation to a separate thread, and allow the executors to return
immediately from the callback. This also allows us to bundle up
multiple update operations into one save, thereby making it work
significantly better in busy deployments.

In a long term, writing out a single big XML for all the records
and rewriting them over and over is highly suboptimal. A quick work
around could be to divide the list up to a chunk of say 1000, and
write one XML for each chunk. This makes the update a constant time
operation regardless of the data size.

Another possibility is to use RDBMS. There has long been a conversation
of implementing the 'database' plugin to provide unified mechanism
for plugins to use embedded/external RDBMS for data storage. I think
this plugin would benefit from that, and maybe it's time we tackle
that problem.
