### PR TITLE
Adding support for the cloudbees folder plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 work
+.classpath
+.settings
+.project

--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,2 @@
+export MAVEN_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n"
+mvn hpi:run

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.428</version>
+    <version>1.609.1</version>
   </parent>
 
   <artifactId>global-build-stats</artifactId>
@@ -20,6 +20,13 @@
       <email>fcamblor+wikihudson@gmail.com</email>
     </developer>
   </developers>
+  <dependencies>
+  	<dependency>
+  <groupId>org.jenkins-ci.plugins</groupId>
+  <artifactId>cloudbees-folder</artifactId>
+  <version>4.9</version>
+</dependency>
+  </dependencies>
     
   <repositories>
     <repository>

--- a/src/main/java/hudson/plugins/global_build_stats/business/GlobalBuildStatsBusiness.java
+++ b/src/main/java/hudson/plugins/global_build_stats/business/GlobalBuildStatsBusiness.java
@@ -4,6 +4,7 @@ import hudson.model.TopLevelItem;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.plugins.global_build_stats.GlobalBuildStatsPlugin;
 import hudson.plugins.global_build_stats.JobBuildResultFactory;
@@ -33,6 +34,8 @@ import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.ui.RectangleEdge;
 import org.jfree.ui.RectangleInsets;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
 
 public class GlobalBuildStatsBusiness {
 
@@ -92,11 +95,15 @@ public class GlobalBuildStatsBusiness {
             public void changePluginStateBeforeSavingIt(GlobalBuildStatsPlugin plugin) {
 
                 List<JobBuildResult> jobBuildResultsRead = new ArrayList<JobBuildResult>();
-
-                //TODO fix MatrixProject and use getAllJobs()
                 for (TopLevelItem item : Hudson.getInstance().getItems()) {
+                	if (item instanceof Folder){
+                		Folder f = (Folder)item;
+                		for (TopLevelItem i : f.getItems()){
+                			handleItem(jobBuildResultsRead,i);
+                		}
+                	}
                     if (item instanceof AbstractProject) {
-                        addBuildsFrom(jobBuildResultsRead, (AbstractProject) item);
+                    	handleItem(jobBuildResultsRead, item);
                     }
                 }
 
@@ -104,6 +111,12 @@ public class GlobalBuildStatsBusiness {
                         CollectionsUtil.<JobBuildResult>minus(jobBuildResultsRead, plugin.getJobBuildResults()));
             }
         });
+	}
+	
+	public void handleItem(List<JobBuildResult> results, TopLevelItem item){
+		if (item instanceof AbstractProject){
+			addBuildsFrom(results, (AbstractProject)item);
+		}
 	}
 	
 	public JFreeChart createChart(BuildStatConfiguration config){


### PR DESCRIPTION
Given projects nested in folders from cloudbees-folder-plugin when initialize stats is clicked in global-stats-plugin then the projects should get registered and able to be retrieved.