### PR TITLE
Fix spelling/grammar in UI resources

### DIFF
--- a/src/main/resources/hudson/plugins/global_build_stats/Messages.properties
+++ b/src/main/resources/hudson/plugins/global_build_stats/Messages.properties
@@ -1,14 +1,14 @@
 Global.Builds.Stats=Global Build Stats
 Displays.stats.about.daily.build.results=Displays stats about daily build results
 # chart category legends : try not to exceed 15 chars here
-Build.Results.Item.Legend.Statuses.NOT_BUILD=1) Not build
-Build.Results.Statuses.NOT_BUILD=Not build
+Build.Results.Item.Legend.Statuses.NOT_BUILD=1) Not built
+Build.Results.Statuses.NOT_BUILD=Not built
 Build.Results.Item.Legend.Statuses.FAILURES=2) Failures
 Build.Results.Statuses.FAILURES=Failures
 Build.Results.Item.Legend.Statuses.ABORTED=3) Aborted
 Build.Results.Statuses.ABORTED=Aborted
-Build.Results.Item.Legend.Statuses.UNSTABLES=4) Unstables
-Build.Results.Statuses.UNSTABLES=Unstables
+Build.Results.Item.Legend.Statuses.UNSTABLES=4) Unstable
+Build.Results.Statuses.UNSTABLES=Unstable
 Build.Results.Item.Legend.Statuses.SUCCESS=5) Success
 Build.Results.Statuses.SUCCESS=Success
 Build.Results.Total.Build.Time=Total build time
@@ -22,7 +22,7 @@ Historic.Scales.Unit.Labels.days=days
 Historic.Scales.Unit.Labels.dayChar=D
 Historic.Scales.Unit.Labels.weeks=weeks
 Historic.Scales.Unit.Labels.weekChar=W
-Historic.Scales.Unit.Labels.monthes=monthes
+Historic.Scales.Unit.Labels.monthes=months
 Historic.Scales.Unit.Labels.years=years
 Historic.Scales.Labels.Hourly=Hourly
 Historic.Scales.Labels.Hourly.From.Now=Hourly from now


### PR DESCRIPTION
Corrects the tense, plurals and spelling of a couple of resources. "Not build" should either be "No build" or "Not built". The second is the most likely given the apparent context.