### PR TITLE
Fix for configuration removal

### DIFF
--- a/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
+++ b/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 
 import javax.servlet.ServletException;
 
@@ -45,6 +48,8 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  */
 @ExportedBean
 public class GlobalBuildStatsPlugin extends Plugin {
+
+    private static final Logger LOGGER = Logger.getLogger(GlobalBuildStatsPlugin.class.getName());
 
     /**
      * List of aggregated job build results
@@ -100,6 +105,11 @@ public class GlobalBuildStatsPlugin extends Plugin {
     * Lock used to synchronize Load/Save methods
     **/
     private final ReentrantLock SaveLoadLock = new ReentrantLock();
+
+    /**
+     * Will be set to true when plugin was loaded 
+     */
+    private boolean wasLoadedFirst = false;
     
     /**
      * Highered visibility of load method
@@ -109,8 +119,11 @@ public class GlobalBuildStatsPlugin extends Plugin {
     public void load() throws IOException {
         this.SaveLoadLock.lock();
         try{
+            LOGGER.log(Level.INFO, "DUPA load start" );
             super.load();
         } finally {
+            LOGGER.log(Level.INFO, "DUPA load end");
+            wasLoadedFirst = true;
             this.SaveLoadLock.unlock();
         }
     }
@@ -121,10 +134,18 @@ public class GlobalBuildStatsPlugin extends Plugin {
      */
     @Override
     public void save() throws IOException {
+
+        while(wasLoadedFirst == false)
+            try{
+                Thread.sleep(1);
+            } catch(Exception e) {}
+        
         this.SaveLoadLock.lock();
         try{
+            LOGGER.log(Level.INFO, "DUPA save start");
             super.save();
         } finally {
+            LOGGER.log(Level.INFO, "DUPA save end");
             this.SaveLoadLock.unlock();
         }
     }

--- a/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
+++ b/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.servlet.ServletException;
 
@@ -96,11 +97,36 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
 
     /**
+    * Lock used to synchronize Load/Save methods
+    **/
+    private final ReentrantLock SaveLoadLock = new ReentrantLock();
+    
+    /**
      * Highered visibility of load method
+     * synchronized with save()
      */
     @Override
     public void load() throws IOException {
-        super.load();
+        this.SaveLoadLock.lock();
+        try{
+            super.load();
+        } finally {
+            this.SaveLoadLock.unlock();
+        }
+    }
+
+    /**
+     * Highered visibility of save method
+     * synchronized with load()
+     */
+    @Override
+    public void save() throws IOException {
+        this.SaveLoadLock.lock();
+        try{
+            super.save();
+        } finally {
+            this.SaveLoadLock.unlock();
+        }
     }
 
     public File getConfigXmlFile() {

--- a/src/main/java/hudson/plugins/global_build_stats/business/GlobalBuildStatsPluginSaver.java
+++ b/src/main/java/hudson/plugins/global_build_stats/business/GlobalBuildStatsPluginSaver.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Date;
 
 /**
  * @author fcamblor
@@ -101,10 +102,14 @@ public class GlobalBuildStatsPluginSaver {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         } catch (NullPointerException x) {
             File f = plugin.getConfigXmlFile();
-            File bak = new File(f.getParentFile(), f.getName() + ".bak");
+
+            Date stamp = new Date();
+
+            File bak = new File(f.getParentFile(), f.getName() + ".bak-"+stamp.getTime());
             if (!f.renameTo(bak)) {
                 LOGGER.log(Level.WARNING, "failed to rename {0} to {1}", new Object[] {f, bak});
             }
+
             LOGGER.log(Level.WARNING, "JENKINS-17248 load failure; saving problematic file to " + bak, x);
         }
     }

--- a/src/main/java/hudson/plugins/global_build_stats/model/JobBuildResultSharder.java
+++ b/src/main/java/hudson/plugins/global_build_stats/model/JobBuildResultSharder.java
@@ -139,9 +139,9 @@ public class JobBuildResultSharder {
                     List<JobBuildResult> jobResultsInFile = (List<JobBuildResult>)Hudson.XSTREAM.fromXML(fr);
                     jobBuildResults.addAll(jobResultsInFile);
                     fr.close();
-                } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE, "Unable to read job results in "+f.getAbsolutePath(), e);
-                    throw new IllegalStateException("Unable to read job results in "+f.getAbsolutePath(), e);
+                } catch (Exception e) {
+                    //just loging issue and ignoring
+                    LOGGER.log(Level.WARNING, "Unable to read job results in "+f.getAbsolutePath(), e);
                 }
             }
         }

--- a/src/main/java/hudson/plugins/global_build_stats/model/JobBuildResultSharder.java
+++ b/src/main/java/hudson/plugins/global_build_stats/model/JobBuildResultSharder.java
@@ -117,14 +117,17 @@ public class JobBuildResultSharder {
 
         for(String filename : updatedFilenames){
             String jobResultFilepath = jobResultsRoot.getAbsolutePath() + File.separator + filename;
+            FileWriter fw = null;
             try {
-                FileWriter fw = new FileWriter(jobResultFilepath);
+                fw = new FileWriter(jobResultFilepath);
                 Hudson.XSTREAM.toXML(persistedMonthlyResults.get(filename), fw);
-                fw.close();
             } catch (IOException e) {
                 LOGGER.log(Level.SEVERE, "Unable to serialize job results into "+jobResultFilepath, e);
                 throw new IllegalStateException("Unable to serialize job results into "+jobResultFilepath, e);
+            } finally {
+                if (fw != null) try { fw.close(); } catch(Exception e) {}
             }
+            
         }
         LOGGER.log(Level.FINER, "Queued changes applied on job results !");
     }
@@ -134,14 +137,33 @@ public class JobBuildResultSharder {
         File jobResultsRoot = getJobResultFolder();
         if(jobResultsRoot.exists()){
             for(File f: jobResultsRoot.listFiles()){
+
+                if (f.getName().contains(".error-"))
+                    continue;
+
+                FileReader fr=null;
                 try {
-                    FileReader fr = new FileReader(f);
+                    fr = new FileReader(f);
                     List<JobBuildResult> jobResultsInFile = (List<JobBuildResult>)Hudson.XSTREAM.fromXML(fr);
                     jobBuildResults.addAll(jobResultsInFile);
-                    fr.close();
+                } catch (IOException e) {
+                    LOGGER.log(Level.SEVERE, "Unable to read job results in "+f.getAbsolutePath(), e);
+
                 } catch (Exception e) {
-                    //just loging issue and ignoring
-                    LOGGER.log(Level.WARNING, "Unable to read job results in "+f.getAbsolutePath(), e);
+                    try { fr.close(); } catch(Exception x) {};
+                    fr = null;
+
+                    Date stamp = new Date();
+                    File bak = new File(f.getParentFile(), f.getName() + ".error-"+stamp.getTime());
+
+                    LOGGER.log(Level.WARNING, "Unable to read job results in "+f.getAbsolutePath()+". Renaming to " + bak, e);
+
+                    if (!f.renameTo(bak)) {
+                        LOGGER.log(Level.WARNING, "failed to rename {0} to {1}", new Object[] {f, bak});
+                    }
+
+                } finally {
+                    if (fr != null) try { fr.close(); } catch(Exception e) {};
                 }
             }
         }


### PR DESCRIPTION
GlobalBuildStats configuration was removed

Root Cause:
\1 if there were issue with Jobresult xml file then major configuration file was destroyed
\2 after second run it was overwritten

Changes I made
\1 Save will not happen before Load
\2 Load is mutually exlusive with Save
\3 Saves are in separate threads there  is only one allowed at a time and others will wait
\4 If there is an issue with Jobresult xml file then it will be ignored and renamed to .error-timestamp 
\5 if there is an issue with major configuration then file will be renamed to .bak-timestamp so in the second run it won’t get overwritten
