### PR TITLE
Prepare spotbugs fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ work
 .classpath
 .settings
 .project
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.609.1</version>
+		<version>4.37</version>
+		<relativePath />
 	</parent>
 
 	<artifactId>global-build-stats</artifactId>
@@ -12,18 +13,6 @@
 	<packaging>hpi</packaging>
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Global+Build+Stats+Plugin</url>
 	<description>Global build stats plugin will allow to gather and display global build result statistics. It is a useful tool allowing to display global hudson build trend over time.</description>
-	
-	<build>
-  		<plugins>
-    			<plugin>
-      				<groupId>org.apache.maven.plugins</groupId>
-      				<artifactId>maven-javadoc-plugin</artifactId>
-      				<configuration>
-        				<additionalparam>-Xdoclint:none</additionalparam>
-      				</configuration>
-    			</plugin>
-  		</plugins>
-	</build>
 
 	<developers>
 		<developer>
@@ -41,7 +30,12 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>cloudbees-folder</artifactId>
-			<version>4.9</version>
+			<version>6.708.ve61636eb_65a_5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.4.1</version>
 		</dependency>
 	</dependencies>
 
@@ -63,6 +57,12 @@
 		<connection>scm:git:git://github.com/jenkinsci/global-build-stats-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/global-build-stats-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/global-build-stats-plugin</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
+
+	<properties>
+		<jenkins.version>2.332.1</jenkins.version>
+		<java.level>8</java.level>
+	</properties>
+
 </project>


### PR DESCRIPTION
Extract the pom part from https://github.com/jenkinsci/global-build-stats-plugin/pull/19 to tackle spotbugs issues separately.