### PR TITLE
Require 2.346.3 as minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
 	<properties>
 		<changelist>999999-SNAPSHOT</changelist>
-		<jenkins.version>2.332.3</jenkins.version>
+		<jenkins.version>2.346.3</jenkins.version>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
## Require 2.346.3 as minimum Jenkins version

I updated the minimum required Jenkins version by setting a `jenkins.version` value in the properties section of the `pom.xml` file

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

