### PR TITLE
[JENKINS-74850] Remove unused inline Javascript handler

### DIFF
--- a/src/main/resources/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin/index.jelly
+++ b/src/main/resources/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin/index.jelly
@@ -100,7 +100,7 @@
         </div>
         <div id="formBlockTemplate">
           <form name="createBuildStat_#{buildStatId}" action="#{formAction}" method="post" class="globalBuildStatsForm"
-                id="createBuildStat_#{buildStatId}" onsubmit="return !isDivErrorPresentInForm(this);">
+                id="createBuildStat_#{buildStatId}">
             <div class="gbs-chart-config">
               #{regenerateIdBlock}
               <div class="gbs-form-row">


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74850

Submission of the form in question seems to never happen. Instead everything is done in JavaScript.
There are a few buttons rendered in the form itself. Two of those (namely "Preview" and "Create new chart"/"Update build stat configuration") have `type` set to `button` which according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#:~:text=The%20button%20has%20no%20default%20behavior%2C%20and%20does%20nothing%20when%20pressed%20by%20default.%20It%20can%20have%20client%2Dside%20scripts%20listen%20to%20the%20element%27s%20events%2C%20which%20are%20triggered%20when%20the%20events%20occur.) makes them have no default behaviour (i.e. no form submission on click).

Preview button:
https://github.com/jenkinsci/global-build-stats-plugin/blob/86d909dce4b71b19a292f074a87c5946775d8efb/src/main/resources/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin/index.jelly#L251

Create new chart/Update build stat (cannot give relevant code pointers, because dialog form is built via JS):
![image](https://github.com/user-attachments/assets/def702c3-df60-4e26-9b4e-b929a5c4971f)

The "Cancel" button does not have its type specified, which means it defaults to `type="submit"`, but it has its default event prevented by https://github.com/jenkinsci/jenkins/blob/deb2a8d896322ba31183ff9921d9f3898a66ca55/src/main/js/components/dialogs/index.js#L166-L172.

### Testing done

Clicked all the buttons I could find in the UI and did not manage to trigger the form submission event. Everything is handled in JavaScript. E.g. what looks to most like a form submission is handled by https://github.com/jenkinsci/global-build-stats-plugin/blob/2c5018728d760ee8201876adc5d7b017674fa973/src/main/webapp/scripts/global-build-stats/BuildStatConfigForm.js#L213-L228

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
