### PR TITLE
Require Jenkins 2.479.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,19 +14,6 @@
     <packaging>hpi</packaging>
     <url>https://github.com/jenkinsci/global-build-stats-plugin</url>
 
-    <developers>
-        <developer>
-            <id>dhinske</id>
-            <name>David Hinske</name>
-            <email>david.hinske@gmx.net</email>
-        </developer>
-        <developer>
-            <id>fcamblor</id>
-            <name>Frederic Camblor</name>
-            <email>fcamblor+wikihudson@gmail.com</email>
-        </developer>
-    </developers>
-
     <dependencies>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -42,7 +29,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3944.v1a_e4f8b_452db_</version>
+                <version>4228.v0a_71308d905b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -66,8 +53,8 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
 
     <scm>

--- a/src/main/java/hudson/plugins/global_build_stats/FromRequestObjectFactory.java
+++ b/src/main/java/hudson/plugins/global_build_stats/FromRequestObjectFactory.java
@@ -6,11 +6,11 @@ import hudson.plugins.global_build_stats.model.BuildStatConfiguration;
 import hudson.plugins.global_build_stats.model.HistoricScale;
 import hudson.plugins.global_build_stats.model.YAxisChartType;
 
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class FromRequestObjectFactory {
 
-	public static BuildHistorySearchCriteria createBuildHistorySearchCriteria(StaplerRequest req){
+	public static BuildHistorySearchCriteria createBuildHistorySearchCriteria(StaplerRequest2 req){
 		BuildSearchCriteria criteria = createBuildSearchCriteria(req);
 		return new BuildHistorySearchCriteria(
 				Long.parseLong(req.getParameter("start")),
@@ -18,7 +18,7 @@ public class FromRequestObjectFactory {
 				criteria);
 	}
 	
-	public static BuildStatConfiguration createBuildStatConfiguration(String id, StaplerRequest req){
+	public static BuildStatConfiguration createBuildStatConfiguration(String id, StaplerRequest2 req){
 		BuildSearchCriteria criteria = createBuildSearchCriteria(req);
     	return new BuildStatConfiguration(
     			id,
@@ -34,7 +34,7 @@ public class FromRequestObjectFactory {
     			criteria);
 	}
 	
-	public static BuildSearchCriteria createBuildSearchCriteria(StaplerRequest req){
+	public static BuildSearchCriteria createBuildSearchCriteria(StaplerRequest2 req){
 		BuildSearchCriteria criteria = new BuildSearchCriteria(req.getParameter("jobFilter"), 
 				req.getParameter("nodeFilter"), 
 				req.getParameter("launcherFilter"),

--- a/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
+++ b/src/main/java/hudson/plugins/global_build_stats/GlobalBuildStatsPlugin.java
@@ -24,15 +24,15 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import net.sf.json.JSONObject;
 
 import org.jfree.chart.JFreeChart;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.export.Flavor;
@@ -85,7 +85,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
 	private transient final GlobalBuildStatsValidator validator = new GlobalBuildStatsValidator();
 	
 	/**
-	 * application/json ContentType for StaplerResponse
+	 * application/json ContentType for StaplerResponse2
 	 */
 	private final static String CONTENT_TYPE = "application/json";
 	
@@ -120,21 +120,21 @@ public class GlobalBuildStatsPlugin extends Plugin {
     		super(bean);
 		}
     	@Override
-    	public void doJson(StaplerRequest req, StaplerResponse rsp)
+    	public void doJson(StaplerRequest2 req, StaplerResponse2 rsp)
     			throws IOException, ServletException {
     		if(!exposeChartData(req, rsp, Flavor.JSON)){
     			super.doJson(req, rsp);
     		}
     	}
     	@Override
-    	public void doPython(StaplerRequest req, StaplerResponse rsp)
+    	public void doPython(StaplerRequest2 req, StaplerResponse2 rsp)
     			throws IOException, ServletException {
     		if(!exposeChartData(req, rsp, Flavor.PYTHON)){
         		super.doPython(req, rsp);
     		}
     	}
     	
-    	private static boolean exposeChartData(StaplerRequest req, StaplerResponse rsp, Flavor flavor) throws ServletException, IOException{
+    	private static boolean exposeChartData(StaplerRequest2 req, StaplerResponse2 rsp, Flavor flavor) throws ServletException, IOException{
     		boolean chartDataHasBeenExposed = false;
     		String buildStatConfigId = req.getParameter("buildStatConfigId");
     		if(buildStatConfigId != null){
@@ -277,13 +277,13 @@ public class GlobalBuildStatsPlugin extends Plugin {
     	
         return new HttpResponse() {
         	@Override
-			public void generateResponse(StaplerRequest req, StaplerResponse rsp,
+			public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp,
 					Object node) throws IOException, ServletException {
 			}
 		};
     }
     
-    public void doShowChart(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doShowChart(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	// Don't check any role : this url is public and should provide a BuildStatConfiguration public id
     	BuildStatConfiguration config = business.searchBuildStatConfigById(req.getParameter("buildStatId"));
     	if(config == null){
@@ -291,20 +291,28 @@ public class GlobalBuildStatsPlugin extends Plugin {
     	}
     	JFreeChart chart = business.createChart(config);
     	
-        ChartUtil.generateGraph(req, res, chart, config.getBuildStatWidth(), config.getBuildStatHeight());
+        ChartUtil.generateGraph(org.kohsuke.stapler.StaplerRequest.fromStaplerRequest2(req),
+                                org.kohsuke.stapler.StaplerResponse.fromStaplerResponse2(res),
+                                chart,
+                                config.getBuildStatWidth(),
+                                config.getBuildStatHeight());
     }
     
-    public void doCreateChart(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doCreateChart(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	// Passing null id since this is a not persisted BuildStatConfiguration
     	BuildStatConfiguration config = FromRequestObjectFactory.createBuildStatConfiguration(null, req);
     	JFreeChart chart = business.createChart(config);
     	
-        ChartUtil.generateGraph(req, res, chart, config.getBuildStatWidth(), config.getBuildStatHeight());
+        ChartUtil.generateGraph(org.kohsuke.stapler.StaplerRequest.fromStaplerRequest2(req),
+                                org.kohsuke.stapler.StaplerResponse.fromStaplerResponse2(res),
+                                chart,
+                                config.getBuildStatWidth(),
+                                config.getBuildStatHeight());
     }
     
-    public void doCreateChartMap(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doCreateChartMap(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
 
     	String buildStatId = req.getParameter("buildStatId");
@@ -317,10 +325,14 @@ public class GlobalBuildStatsPlugin extends Plugin {
     	}
     	JFreeChart chart = business.createChart(config);
     	
-        ChartUtil.generateClickableMap(req, res, chart, config.getBuildStatWidth(), config.getBuildStatHeight());
+        ChartUtil.generateClickableMap(org.kohsuke.stapler.StaplerRequest.fromStaplerRequest2(req),
+                                       org.kohsuke.stapler.StaplerResponse.fromStaplerResponse2(res),
+                                       chart,
+                                       config.getBuildStatWidth(),
+                                       config.getBuildStatHeight());
     }
     
-    public void doBuildHistory(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doBuildHistory(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	BuildHistorySearchCriteria searchCriteria = FromRequestObjectFactory.createBuildHistorySearchCriteria(req);
@@ -333,7 +345,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
     
     @RequirePOST
-    public void doUpdateBuildStatConfiguration(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doUpdateBuildStatConfiguration(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	boolean regenerateId = Boolean.parseBoolean(req.getParameter("regenerateId"));
@@ -347,7 +359,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
     
     @RequirePOST
-    public void doAddBuildStatConfiguration(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doAddBuildStatConfiguration(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	BuildStatConfiguration config = FromRequestObjectFactory.createBuildStatConfiguration(ModelIdGenerator.INSTANCE.generateIdForClass(BuildStatConfiguration.class), req);
@@ -359,7 +371,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
     
     @RequirePOST
-    public void doDeleteConfiguration(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doDeleteConfiguration(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	business.deleteBuildStatConfiguration(req.getParameter("buildStatId"));
@@ -368,7 +380,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
     
     @RequirePOST
-    public void doMoveUpConf(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doMoveUpConf(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	business.moveUpConf(req.getParameter("buildStatId"));
@@ -377,7 +389,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
     
     @RequirePOST
-    public void doMoveDownConf(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doMoveDownConf(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
     	Hudson.getInstance().checkPermission(getRequiredPermission());
     	
     	business.moveDownConf(req.getParameter("buildStatId"));
@@ -386,7 +398,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
     }
 
     @RequirePOST
-    public void doUpdateRetentionStrategies(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
+    public void doUpdateRetentionStrategies(StaplerRequest2 req, StaplerResponse2 res) throws ServletException, IOException {
         Hudson.getInstance().checkPermission(getRequiredPermission());
 
         List<RetentionStrategy> selectedStrategies = new ArrayList<RetentionStrategy>();
@@ -403,7 +415,7 @@ public class GlobalBuildStatsPlugin extends Plugin {
         respondAjaxOk(res);
     }
 
-    protected static void respondAjaxOk(StaplerResponse res) throws IOException {
+    protected static void respondAjaxOk(StaplerResponse2 res) throws IOException {
         res.getWriter().write("{ status : 'ok' }");
     }
     


### PR DESCRIPTION
## Require Jenkins 2.479.3

- Require Jenkins 2.479.3
- Bump org.jenkins-ci.plugins:plugin from 4.88 to 5.7

### Testing done

Confirmed that automated tests pass.

Confirmed that interactive testing is able to display a global graph with build statistics.

Confirmed that the one dependent plugin uses none of the modified API signatures.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
